### PR TITLE
Also persist .logseq

### DIFF
--- a/com.logseq.Logseq.json
+++ b/com.logseq.Logseq.json
@@ -21,7 +21,8 @@
         "--socket=x11",
         "--socket=pulseaudio",
         "--share=network",
-        "--filesystem=home"
+        "--filesystem=home",
+        "--persist=.logseq"
     ],
     "modules": [
         {


### PR DESCRIPTION
Without it, Logseq cannot remember opened graphs.