### PR TITLE
Adding "--device=dri" to the list of "finish-args"

### DIFF
--- a/com.logseq.Logseq.json
+++ b/com.logseq.Logseq.json
@@ -21,6 +21,7 @@
         "--socket=x11",
         "--socket=pulseaudio",
         "--share=network",
+        "--device=dri",
         "--filesystem=home"
     ],
     "modules": [


### PR DESCRIPTION
As @kanru [commented](https://github.com/flathub/com.logseq.Logseq/issues/2#issuecomment-1020666364) on #2,
> should allow Logseq to use DRI and enable hardware acceleration.

Solves #2.