### PR TITLE
chore: Update w/ Wayland support and metadata

### DIFF
--- a/com.logseq.Logseq.desktop
+++ b/com.logseq.Logseq.desktop
@@ -1,9 +1,16 @@
 [Desktop Entry]
-Type=Application
-NoDisplay=false
+Name=Logseq Desktop
+Exec=run.sh %U --enable-features=UseOzonePlatform --ozone-platform-hint=auto --enable-features=WaylandWindowDecorations
 Terminal=false
-Exec=run.sh %U
+Type=Application
 Icon=com.logseq.Logseq
-Name=Logseq
-Categories=Office
+StartupWMClass=Logseq
+Comment=A privacy-first, open-source platform for knowledge management and collaboration.
 MimeType=x-scheme-handler/logseq;
+Categories=Utility;office;
+NoDisplay=false
+Actions=Wayland;
+
+[Desktop Action Wayland]
+Name=Wayland Backend
+Exec=run.sh %U --enable-features=UseOzonePlatform --ozone-platform=wayland --enable-features=WaylandWindowDecorations

--- a/com.logseq.Logseq.desktop
+++ b/com.logseq.Logseq.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=Logseq Desktop
-Exec=run.sh %U --enable-features=UseOzonePlatform --ozone-platform-hint=auto --enable-features=WaylandWindowDecorations
+Exec=run.sh %U
 Terminal=false
 Type=Application
 Icon=com.logseq.Logseq


### PR DESCRIPTION
This commit updates the desktop entry file to include Wayland support and additional features. The changes include:

- Renaming the app to "Logseq Desktop" to match upstream
- Adding an option to force Wayland backend
- Enabling Wayland window decorations with the --enable-features=WaylandWindowDecorations flag
- Updating metadata ￼


This update is an effort into making the flatpack .desktop file closer to the [upstream file](https://github.com/logseq/logseq/pull/7219):
```sh
[Desktop Entry]
Name=Logseq
Exec=Logseq %u
Terminal=false
Type=Application
Icon=Logseq
StartupWMClass=Logseq
X-AppImage-Version=0.8.10
Comment=A privacy-first, open-source platform for knowledge management and collaboration.
MimeType=x-scheme-handler/logseq
Categories=Utility
```


I added to the desktop some extra improvements brought from my Arch Linux package for Logseq and based on users' feedback. 