### PR TITLE
Add check to release files

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -64,6 +64,8 @@ jobs:
         run: pipx install "git+https://github.com/flatpak/flatpak-builder-tools.git#subdirectory=node"
       - name: Generate dependency manifests
         run: ./01-sync-release.sh ${{ inputs.version }}
+      - name: Check files were correctly created
+        run: ./02-check-release.sh
       - uses: docker://ghcr.io/flathub/flatpak-external-data-checker:latest
         env:
           GIT_AUTHOR_NAME: Flatpak External Data Checker

--- a/02-check-release.sh
+++ b/02-check-release.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+FILES=(
+    "maven-sources.json"
+    "static/yarn.lock"
+    "generated-sources.json"
+)
+
+errors=0
+for (( i = 0; i < ${#FILES[@]}; i++ )); do
+    # []\n\0 is just 4 bytes
+    f="${FILES[$i]}"
+    if [ ! -f "$f" ]; then
+        echo The file "$f" does not exist>&2
+        errors=1
+        continue
+    fi
+    fsize=$(stat -c%s "$f")
+    if (( fsize <= 4 )); then
+        echo The file "$f" seems to be empty>&2
+        cat "$f"
+        errors=1
+    fi
+done
+
+exit $errors
+


### PR DESCRIPTION
I created a script called `02-check-release.sh` that just checks that the files aren't `[]` or `{}` and nothing else, to avoid repeating a situation like #87 

It should run in the Github action, before even creating the PR and starting a build that would fail