### PR TITLE
Updated metainfo to 0.9.14

### DIFF
--- a/com.logseq.Logseq.metainfo.xml
+++ b/com.logseq.Logseq.metainfo.xml
@@ -58,6 +58,7 @@
     <url type="contact">https://discuss.logseq.com/</url>
 
     <releases>
+        <release version="0.9.14" date="2023-08-17"/>
         <release version="0.9.13" date="2023-08-03"/>
         <release version="0.9.12" date="2023-08-02"/>
         <release version="0.9.11" date="2023-07-21"/>


### PR DESCRIPTION
Sorry, as I ran the files manually, I forgot to update the metainfo. The correct files are on flathub, but it says "version 0.9.13" and it doesn't automatically update.