### PR TITLE
Change cron minute in update.yml

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,7 +1,7 @@
 name: Check for updates
 on:
   schedule:
-    - cron: '0 * * * *'
+    - cron: '33 * * * *'
   workflow_dispatch:
     inputs:
       force:


### PR DESCRIPTION
It seems that the workflow doesn't execute sometimes, or it executes way later. This is because the load of the GitHub runners is too high at X o'clock. I generated a random number between 10 and 50 and now it will run at that minute.

> Note: The schedule event can be delayed during periods of high loads of GitHub Actions workflow runs. High load times include the start of every hour. If the load is sufficiently high enough, some queued jobs may be dropped. To decrease the chance of delay, schedule your workflow to run at a different time of the hour.
> -- https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule