### PR TITLE
fix: remove filter from SVG icon

### DIFF
--- a/com.logseq.Logseq.svg
+++ b/com.logseq.Logseq.svg
@@ -1,15 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="128" height="128" version="1.1" viewBox="0 0 33.867 33.867" xmlns="http://www.w3.org/2000/svg">
-  <defs>
-    <filter id="filter32698" x="-.033044" y="-.033044" width="1.0799" height="1.0799" color-interpolation-filters="sRGB">
-      <feFlood flood-color="rgb(0,0,0)" flood-opacity=".49804" result="flood"/>
-      <feComposite in="flood" in2="SourceGraphic" operator="in" result="composite1"/>
-      <feGaussianBlur in="composite1" result="blur" stdDeviation="3"/>
-      <feOffset dx="3" dy="3" result="offset"/>
-      <feComposite in="SourceGraphic" in2="offset" result="composite2"/>
-    </filter>
-  </defs>
-  <g transform="matrix(.14394 0 0 .14361 14.231 14.634)" filter="url(#filter32698)">
+  <g transform="matrix(.14394 0 0 .14361 14.231 14.634)">
     <rect x="-91.67" y="-94.693" width="217.89" height="217.89" ry="49.84" fill="#002b34"/>
     <g fill="#86c8c8">
       <ellipse transform="matrix(.66125 .75016 -.77588 .63088 0 0)" cx="-57.519" cy="10.486" rx="31.704" ry="28.51"/>


### PR DESCRIPTION
This workarounds a regression in Qt6.7 SVG renderer.

Fixes #136 