### PR TITLE
fix: Try opening with Wayland before using x11

### DIFF
--- a/com.logseq.Logseq.yml
+++ b/com.logseq.Logseq.yml
@@ -14,7 +14,7 @@ command: run.sh
 finish-args:
   - --device=dri
   - --share=ipc
-  - --socket=x11
+  - --socket=fallback-x11
   - --socket=wayland
   - --socket=pulseaudio
   - --share=network


### PR DESCRIPTION
Modify the flatpak configuration to use the `fallback-x11` option, allowing it to attempt opening with `Wayland` before falling back to `X11` if necessary.   
This change eliminates the need to manually launch the app with the `--socket=wayland` option if `xwayland` is installed.

## Reference:
- https://www.reddit.com/r/Fedora/comments/tpsret/comment/i2dht5n